### PR TITLE
Add GitHub templates and demo seed layout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report a reproducible problem in Cardiac Matchmaker
+title: "bug: "
+labels: ["bug"]
+assignees: ""
+---
+
+## Problem
+
+Describe what is broken.
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+Describe what should happen.
+
+## Actual behavior
+
+Describe what happens instead.
+
+## Area
+
+- [ ] Backend
+- [ ] Frontend
+- [ ] Worker / data pipeline
+- [ ] Documentation
+- [ ] CI / project setup
+
+## Environment
+
+- OS:
+- Browser, if frontend:
+- Docker used: yes / no
+
+## Extra context
+
+Add logs, screenshots, request payloads, or links if helpful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Project repository
+    url: https://github.com/ugotgnomedha/Cardiac-Matchmaker
+    about: Read the README and project setup notes before opening setup questions.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,33 @@
+---
+name: Task
+about: Plan an implementation task for the project
+title: "task: "
+labels: ["task"]
+assignees: ""
+---
+
+## Goal
+
+Describe the project outcome this task should support.
+
+## Background
+
+Explain the relevant context, data, route, model, or workflow.
+
+## Scope
+
+- [ ] Backend
+- [ ] Frontend
+- [ ] Worker / data pipeline
+- [ ] Documentation
+- [ ] CI / project setup
+
+## Acceptance criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Notes
+
+Add links, examples, or implementation hints.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,30 @@
+- name: backend
+  color: "1d76db"
+  description: Backend API, models, services, repositories, and database work
+- name: frontend
+  color: "0e8a16"
+  description: React UI, pages, components, and client-side behavior
+- name: worker
+  color: "5319e7"
+  description: Background jobs, data processing, and pipeline execution
+- name: data
+  color: "fbca04"
+  description: Dataset ingestion, preprocessing, normalization, and storage
+- name: research
+  color: "c2e0c6"
+  description: Literature retrieval, evidence, matching logic, and explainability
+- name: bug
+  color: "d73a4a"
+  description: Something is broken or behaves incorrectly
+- name: task
+  color: "c5def5"
+  description: Planned implementation work
+- name: documentation
+  color: "0075ca"
+  description: README, project notes, templates, and developer documentation
+- name: ci
+  color: "fef2c0"
+  description: GitHub Actions, checks, linting, tests, and build setup
+- name: good first issue
+  color: "7057ff"
+  description: Small, clear task suitable for a first contribution

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Type of change
+
+- [ ] Backend
+- [ ] Frontend
+- [ ] Worker / data pipeline
+- [ ] Documentation
+- [ ] CI / project setup
+
+## Checklist
+
+- [ ] I linked the related issue.
+- [ ] I kept the change focused on the issue scope.
+- [ ] I added or updated tests where useful.
+- [ ] I ran the relevant checks locally.
+- [ ] I updated documentation if behavior or setup changed.
+
+## Testing
+
+List the commands you ran and the result.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ FastAPI + Peewee + cookie JWT auth. `POST /api/v1/auth/login` sets `access_token
 docker compose exec backend python -m app.cmd.create_user admin@example.com --superuser
 ```
 
+## Demo data
+
+Create the development storage layout and seed a demo research project:
+
+```bash
+docker compose exec backend python -m app.cmd.seed_demo
+```
+
+The seed command creates `data/raw`, `data/processed`, `data/pdfs`, `data/logs`, and `data/reports`.
+
 ## .env
 
 ```env

--- a/backend/app/cmd/seed_demo.py
+++ b/backend/app/cmd/seed_demo.py
@@ -1,0 +1,136 @@
+import argparse
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, TypedDict
+
+from app.cmd.migrate import ensure_migrations_applied
+from app.models.base.base_model import db
+from app.models.dataset.dataset_model import Dataset, DatasetVersion
+from app.models.project.project_model import ResearchProject
+
+
+DEFAULT_STORAGE_DIRS = ("raw", "processed", "pdfs", "logs", "reports")
+
+
+class SeedResult(TypedDict):
+    storage_paths: dict[str, Path]
+    project: ResearchProject
+    project_created: bool
+    dataset: Dataset
+    dataset_created: bool
+    dataset_version: DatasetVersion
+    version_created: bool
+
+
+def get_repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def create_storage_layout(storage_root: Path) -> dict[str, Path]:
+    paths = {}
+    for directory_name in DEFAULT_STORAGE_DIRS:
+        path = storage_root / directory_name
+        path.mkdir(parents=True, exist_ok=True)
+        paths[directory_name] = path
+    return paths
+
+
+def get_first_or_create(model, defaults: dict[str, Any] | None = None, **query):
+    expressions = [getattr(model, field_name) == value for field_name, value in query.items()]
+    instance = model.select().where(*expressions).first()
+    if instance is not None:
+        return instance, False
+
+    values = dict(query)
+    if defaults:
+        values.update(defaults)
+    return model.create(**values), True
+
+
+def seed_demo_project(storage_root: Path) -> SeedResult:
+    storage_paths = create_storage_layout(storage_root)
+
+    project, project_created = get_first_or_create(
+        ResearchProject,
+        name="Demo Cardiac Matchmaker Project",
+        defaults={
+            "description": (
+                "Demo project for placenta-to-cardiac tissue matching with raw uploads, "
+                "processed artifacts, literature PDFs, logs, and reports."
+            )
+        },
+    )
+
+    dataset, dataset_created = get_first_or_create(
+        Dataset,
+        project=project,
+        name="Demo placenta proteomics dataset",
+        defaults={
+            "type": "placenta",
+            "original_filename": "demo_placenta_proteomics.tsv",
+            "storage_path": str(storage_paths["raw"] / "demo_placenta_proteomics.tsv"),
+            "metadata": {
+                "source": "demo",
+                "tissue_regions": ["amnion", "chorion", "basal tissue", "umbilical cord"],
+                "purpose": "seed data for development",
+            },
+        },
+    )
+
+    dataset_version, version_created = get_first_or_create(
+        DatasetVersion,
+        dataset=dataset,
+        version_number="1",
+        defaults={
+            "status": "raw",
+            "storage_path": dataset.storage_path,
+            "preprocessing_config": {"normalization": "pending"},
+        },
+    )
+
+    return {
+        "storage_paths": storage_paths,
+        "project": project,
+        "project_created": project_created,
+        "dataset": dataset,
+        "dataset_created": dataset_created,
+        "dataset_version": dataset_version,
+        "version_created": version_created,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed demo Cardiac Matchmaker project data")
+    parser.add_argument(
+        "--storage-root",
+        default=str(get_repo_root() / "data"),
+        help="Root directory for raw, processed, pdfs, logs, and reports folders.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    storage_root = Path(args.storage_root).resolve()
+
+    try:
+        db.connect(reuse_if_open=True)
+        ensure_migrations_applied()
+        result = seed_demo_project(storage_root)
+    finally:
+        if not db.is_closed():
+            db.close()
+
+    print(f"Storage root: {storage_root}")
+    for name, path in result["storage_paths"].items():
+        print(f" - {name}: {path}")
+
+    print(f"Project: {result['project'].name} ({result['project'].id})")
+    print(f"Dataset: {result['dataset'].name} ({result['dataset'].id})")
+    print(f"Dataset version: {result['dataset_version'].version_number} ({result['dataset_version'].id})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #2
Closes #13

Summary:
- Added GitHub issue templates, PR template, and labels config.
- Added demo seed command for project, dataset, dataset version, and storage folders.
- Seed command creates raw, processed, pdfs, logs, and reports directories.
- Seed command is safe to run multiple times.

Testing:
- docker compose exec -T backend python -m app.cmd.seed_demo
- docker compose exec -T backend python -m app.cmd.seed_demo
- docker compose exec -T backend python -m pytest

Result:
- seed_demo reused the same demo records on repeated runs
- 14 passed